### PR TITLE
PMI fixed

### DIFF
--- a/harvesttext/sent_dict.py
+++ b/harvesttext/sent_dict.py
@@ -50,6 +50,7 @@ class SentDict(object):
         co_occur = dict()               # 由于defaultdict太占内存，还是使用dict
         one_occur = dict()
         for doc in docs:
+            doc = set(doc)
             for word in doc:
                 if not word in one_occur:
                     one_occur[word] = 1


### PR DESCRIPTION
PMI中的概率的分母是文本数量，也就是说统计的时候只需要统计每个词汇，或者是词汇组出现的文章数量。

但检验的时候，发现（下面的两个输出分别是：1. 在分词结束后的输出，2.统计完成后对于one_occur的输出）。会发现，这里只有一篇文章，但是统计的结果却为2。
```python
>>> from harvesttext import HarvestText
>>> ht = HarvestText()
>>> docs = ["中国牛中国牛"]
>>> ht.build_sent_dict(docs)
Building prefix dict from the default dictionary ...
Loading model from cache C:\Users\lijy2\AppData\Local\Temp\jieba.cache
Loading model cost 0.710 seconds.
Prefix dict has been built succesfully.
['中国', '牛', '中国', '牛']
{'中国': 2, '牛': 2}
```