### PR TITLE
Sentiment Analysis Improvement（Stopwords Considered）

### DIFF
--- a/harvesttext/harvesttext.py
+++ b/harvesttext/harvesttext.py
@@ -767,7 +767,8 @@ class HarvestText:
     #
     # 情感分析模块
     #
-    def build_sent_dict(self, sents, method="PMI", min_times=5, scale="None", pos_seeds=None, neg_seeds=None):
+    def build_sent_dict(self, sents, method="PMI", min_times=5, scale="None",
+                        pos_seeds=None, neg_seeds=None, stopwords=None):
         '''
         利用种子词，构建情感词典
         :param sents: list of string, 文本列表
@@ -778,12 +779,18 @@ class HarvestText:
         若为"+-1", 在正负区间内分别伸缩，保留0作为中性的语义
         :param pos_seeds: list of string, 积极种子词，如不填写将默认采用清华情感词典
         :param neg_seeds: list of string, 消极种子词，如不填写将默认采用清华情感词典
+        :param stopwords: list of string, stopwords词，如不填写将不使用
         :return: sent_dict: 构建好的情感词典，可以像dict一样查询单个词语的情感值
         '''
         if pos_seeds is None or neg_seeds is None:
             sdict = get_qh_sent_dict()
             pos_seeds, neg_seeds = sdict["pos"], sdict["neg"]
-        docs = [self.seg(sent) for sent in sents]
+        docs = [set(self.seg(sent)) for sent in sents]
+        if not stopwords is None:
+            stopwords = set(stopwords)
+            for i in range(len(docs)):
+                docs[i] = docs[i] - stopwords
+            docs = list(filter(lambda x: len(x) > 0, docs))
         self.sent_dict = SentDict(docs, method, min_times, scale, pos_seeds, neg_seeds)
         return self.sent_dict
 

--- a/harvesttext/sent_dict.py
+++ b/harvesttext/sent_dict.py
@@ -27,10 +27,10 @@ class SentDict(object):
             if method == "PMI":
                 self.co_occur, self.one_occur = self.get_word_stat(docs)
                 self.words = set(word for word in self.one_occur if self.one_occur[word]>=min_times)
-                if len(pos_seeds) > 0 and len(neg_seeds) > 0:     # 如果有新的输入，就更新种子词，否则默认已有（比如通过set已设定）
+                if len(pos_seeds) > 0 or len(neg_seeds) > 0:     # 如果有新的输入，就更新种子词，否则默认已有（比如通过set已设定）
                     self.pos_seeds = (pos_seeds & self.words)
                     self.neg_seeds = (neg_seeds & self.words)
-                if len(self.pos_seeds) > 0 and len(self.neg_seeds) > 0:
+                if len(self.pos_seeds) > 0 or len(self.neg_seeds) > 0:
                     self.sent_dict = self.SO_PMI(self.words, scale)
                 else:
                     raise Exception("你的文章中不包含种子词，SO-PMI算法无法执行")
@@ -50,7 +50,6 @@ class SentDict(object):
         co_occur = dict()               # 由于defaultdict太占内存，还是使用dict
         one_occur = dict()
         for doc in docs:
-            doc = set(doc)
             for word in doc:
                 if not word in one_occur:
                     one_occur[word] = 1


### PR DESCRIPTION
关于情感分析，这里做了两个主要的改进：

1. 之前的训练当中夹杂着大量的stopwords或者那些Meaningless vocabularies. 训练的时候这些词汇也被考虑进去了，导致了训练的结果非常不理想。（即大量的stopwords也被赋予了特定的含义，但实际上是无意义的，但这些stopwords和pos或者是neg都会高度一致的出现，使得他们的分数理论上会接近于pos和neg的种子词汇的某种数学关系。根据SO-PMI的计算方式，可以看到训练的模型输出的分数的期望**理论上(stopwords足够多)**是会收敛到（pos - neg）/(pos + neg)。（在我们这，由于默认的数据集中pos词汇大于neg中，因此最后的结果很大概率会是pos））
2. 如果训练集中只有某一类的（pos or neg）的话，理论上也是可以计算的。